### PR TITLE
Implement text serialization methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [0.7.1] - 2023-04-17
+
+### Changed
+
+- Implement serialization and parseNode listeners.
+
 ## [0.7.0] - 2023-01-23
 
 ### Added

--- a/text_parse_node.go
+++ b/text_parse_node.go
@@ -14,7 +14,9 @@ import (
 
 // TextParseNode is a ParseNode implementation for JSON.
 type TextParseNode struct {
-	value string
+	value                     string
+	onBeforeAssignFieldValues absser.ParsableAction
+	onAfterAssignFieldValues  absser.ParsableAction
 }
 
 // NewTextParseNode creates a new TextParseNode.
@@ -251,20 +253,22 @@ func (n *TextParseNode) GetRawValue() (interface{}, error) {
 
 // GetOnBeforeAssignFieldValues returns a ByteArray value from the nodes.
 func (n *TextParseNode) GetOnBeforeAssignFieldValues() absser.ParsableAction {
-	return nil
+	return n.onBeforeAssignFieldValues
 }
 
 // SetOnBeforeAssignFieldValues returns a ByteArray value from the nodes.
 func (n *TextParseNode) SetOnBeforeAssignFieldValues(action absser.ParsableAction) error {
-	return UnsupportedMethodError
+	n.onBeforeAssignFieldValues = action
+	return nil
 }
 
 // GetOnAfterAssignFieldValues returns a ByteArray value from the nodes.
 func (n *TextParseNode) GetOnAfterAssignFieldValues() absser.ParsableAction {
-	return nil
+	return n.onAfterAssignFieldValues
 }
 
 // SetOnAfterAssignFieldValues returns a ByteArray value from the nodes.
 func (n *TextParseNode) SetOnAfterAssignFieldValues(action absser.ParsableAction) error {
-	return UnsupportedMethodError
+	n.onAfterAssignFieldValues = action
+	return nil
 }

--- a/text_parse_node_test.go
+++ b/text_parse_node_test.go
@@ -31,9 +31,15 @@ func TestTextParseNodeHonoursInterface(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Implements(t, (*absser.ParseNode)(nil), instance)
 
-	err = instance.SetOnBeforeAssignFieldValues(nil)
-	assert.NoError(t, err)
+	action := func(parsable absser.Parsable) error {
+		return nil
+	}
 
-	err = instance.SetOnAfterAssignFieldValues(nil)
+	err = instance.SetOnBeforeAssignFieldValues(action)
 	assert.NoError(t, err)
+	assert.NotNil(t, instance.GetOnBeforeAssignFieldValues())
+
+	err = instance.SetOnAfterAssignFieldValues(action)
+	assert.NoError(t, err)
+	assert.NotNil(t, instance.GetOnAfterAssignFieldValues())
 }

--- a/text_parse_node_test.go
+++ b/text_parse_node_test.go
@@ -30,4 +30,10 @@ func TestTextParseNodeHonoursInterface(t *testing.T) {
 	instance, err := NewTextParseNode(sourceArray)
 	assert.Nil(t, err)
 	assert.Implements(t, (*absser.ParseNode)(nil), instance)
+
+	err = instance.SetOnBeforeAssignFieldValues(nil)
+	assert.NoError(t, err)
+
+	err = instance.SetOnAfterAssignFieldValues(nil)
+	assert.NoError(t, err)
 }

--- a/text_serialization_writer.go
+++ b/text_serialization_writer.go
@@ -14,11 +14,13 @@ import (
 
 var NoStructuredDataError = errors.New("text does not support structured data")
 var OnlyOneValue = errors.New("text serialization writer can only write one value")
-var UnsupportedMethodError = errors.New("text does not support current method")
 
 // TextSerializationWriter implements SerializationWriter for JSON.
 type TextSerializationWriter struct {
-	writer []string
+	writer                     []string
+	onBeforeAssignFieldValues  absser.ParsableAction
+	onAfterAssignFieldValues   absser.ParsableAction
+	onStartObjectSerialization absser.ParsableWriter
 }
 
 // NewTextSerializationWriter creates a new instance of the TextSerializationWriter.
@@ -257,25 +259,28 @@ func (w *TextSerializationWriter) WriteNullValue(key string) error {
 }
 
 func (w *TextSerializationWriter) GetOnBeforeSerialization() absser.ParsableAction {
-	return nil
+	return w.onBeforeAssignFieldValues
 }
 
 func (w *TextSerializationWriter) SetOnBeforeSerialization(action absser.ParsableAction) error {
-	return UnsupportedMethodError
+	w.onBeforeAssignFieldValues = action
+	return nil
 }
 
 func (w *TextSerializationWriter) GetOnAfterObjectSerialization() absser.ParsableAction {
-	return nil
+	return w.onAfterAssignFieldValues
 }
 
 func (w *TextSerializationWriter) SetOnAfterObjectSerialization(action absser.ParsableAction) error {
-	return UnsupportedMethodError
-}
-
-func (w *TextSerializationWriter) GetOnStartObjectSerialization() absser.ParsableWriter {
+	w.onAfterAssignFieldValues = action
 	return nil
 }
 
+func (w *TextSerializationWriter) GetOnStartObjectSerialization() absser.ParsableWriter {
+	return w.onStartObjectSerialization
+}
+
 func (w *TextSerializationWriter) SetOnStartObjectSerialization(writer absser.ParsableWriter) error {
-	return UnsupportedMethodError
+	w.onStartObjectSerialization = writer
+	return nil
 }

--- a/text_serialization_writer_test.go
+++ b/text_serialization_writer_test.go
@@ -27,6 +27,7 @@ func TestTextSerializationWriter(t *testing.T) {
 	}
 	err := serializer.SetOnBeforeSerialization(onBefore)
 	assert.NoError(t, err)
+	assert.NotNil(t, serializer.GetOnBeforeSerialization())
 
 	countAfter := 0
 	onAfter := func(parsable absser.Parsable) error {
@@ -35,6 +36,7 @@ func TestTextSerializationWriter(t *testing.T) {
 	}
 	err = serializer.SetOnAfterObjectSerialization(onAfter)
 	assert.NoError(t, err)
+	assert.NotNil(t, serializer.GetOnAfterObjectSerialization())
 
 	countStart := 0
 	onStart := func(absser.Parsable, absser.SerializationWriter) error {
@@ -44,4 +46,5 @@ func TestTextSerializationWriter(t *testing.T) {
 
 	err = serializer.SetOnStartObjectSerialization(onStart)
 	assert.NoError(t, err)
+	assert.NotNil(t, serializer.GetOnStartObjectSerialization())
 }

--- a/text_serialization_writer_test.go
+++ b/text_serialization_writer_test.go
@@ -17,3 +17,31 @@ func TestSerializationWriterHonoursInterface(t *testing.T) {
 	instance := NewTextSerializationWriter()
 	assert.Implements(t, (*absser.SerializationWriter)(nil), instance)
 }
+
+func TestTextSerializationWriter(t *testing.T) {
+	serializer := NewTextSerializationWriter()
+	countBefore := 0
+	onBefore := func(parsable absser.Parsable) error {
+		countBefore++
+		return nil
+	}
+	err := serializer.SetOnBeforeSerialization(onBefore)
+	assert.NoError(t, err)
+
+	countAfter := 0
+	onAfter := func(parsable absser.Parsable) error {
+		countAfter++
+		return nil
+	}
+	err = serializer.SetOnAfterObjectSerialization(onAfter)
+	assert.NoError(t, err)
+
+	countStart := 0
+	onStart := func(absser.Parsable, absser.SerializationWriter) error {
+		countStart++
+		return nil
+	}
+
+	err = serializer.SetOnStartObjectSerialization(onStart)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
Resolves https://github.com/microsoftgraph/msgraph-sdk-go/issues/466

`UnsupportedMethodError` gets thrown on the abstraction layer when invoked for text serialization when attempting to wrap serialization on text node factories. 